### PR TITLE
Beware case sensitivity

### DIFF
--- a/src/control_tlv320aic3104.cpp
+++ b/src/control_tlv320aic3104.cpp
@@ -272,6 +272,6 @@ bool AudioControlTLV320AIC3104::stopAudio()
 #include "tlv320aic3104_pll.h" 
 #include "tlv320aic3104_filters.h" 
 #include "tlv320aic3104_DAC_filters.h"
-#include "AGC.h"
+#include "agc.h"
 
 


### PR DESCRIPTION
Case sensitivity for header files is relevant for some platforms, e.g. arduino-cli based builds under linux.